### PR TITLE
Feature: Implement unary operators

### DIFF
--- a/halcyon.cabal
+++ b/halcyon.cabal
@@ -32,6 +32,7 @@ library
         , Halcyon.Frontend.Tokens
         , Halcyon.Backend.Codegen
         , Halcyon.Backend.Emit
+        , Halcyon.Backend.ReplacePseudos
         , Halcyon.Driver.Cli
         , Halcyon.Driver.Pipeline
     -- other-extensions:

--- a/halcyon.cabal
+++ b/halcyon.cabal
@@ -25,6 +25,8 @@ library
         , Halcyon.Core.Ast
         , Halcyon.Core.Assembly
         , Halcyon.Core.Monad
+        , Halcyon.Core.Tacky
+        , Halcyon.Core.TackyGen
         , Halcyon.Frontend.Lexer
         , Halcyon.Frontend.Parse
         , Halcyon.Frontend.Tokens

--- a/lib/Halcyon.hs
+++ b/lib/Halcyon.hs
@@ -16,4 +16,4 @@ import Halcyon.Core.Settings
 import Halcyon.Core.Ast (Program(..))
 import Halcyon.Driver.Pipeline
 import Halcyon.Driver.Cli
-import Halcyon.Frontend.Parse
+import Halcyon.Frontend.Parse ( parseTokens )

--- a/lib/Halcyon/Backend/Emit.hs
+++ b/lib/Halcyon/Backend/Emit.hs
@@ -6,9 +6,17 @@ import qualified Halcyon.Core.Assembly as Asm
 import Data.Text ( Text )
 import qualified Data.Text as T
 
+
 showOperand :: Asm.Operand -> Text
-showOperand Asm.Register = "%eax"
+showOperand (Asm.Register Asm.Ax) = "%eax"
+showOperand (Asm.Register Asm.R10) = "%r10d"
 showOperand (Asm.Imm i) = "$" <> T.pack (show i)
+showOperand (Asm.Stack i) = T.pack (show i) <> "(%rbp)"
+showOperand (Asm.Pseudo name) = "%" <> name
+
+showOperator :: Asm.UnaryOp -> Text
+showOperator Asm.Not = "notl"
+showOperator Asm.Neg = "negl"
 
 --let show_label name =
 --  match !Settings.platform with OS_X -> "_" ^ name | Linux -> name
@@ -16,17 +24,22 @@ showOperand (Asm.Imm i) = "$" <> T.pack (show i)
 emitInstruction :: Asm.Instruction -> Text
 emitInstruction (Asm.Mov src dest) =
   "\tmovl " <> showOperand src <> ", " <> showOperand dest <> "\n"
-emitInstruction Asm.Ret =
-  "\tret\n"
-
+emitInstruction (Asm.AllocateStack i) = 
+  "\tsubq $" <> T.pack (show i) <> ", %rsp\n"
+emitInstruction (Asm.Unary op operand) = 
+  "\t" <> showOperator op <> " " <> showOperand operand <> "\n"
+emitInstruction Asm.Ret = 
+  "\tmovq %rbp, %rsp\n\tpopq %rbp\n\tret\n"
 
 emitFunction :: Asm.FunctionDef -> Text
 emitFunction Asm.Function{..} =
   let
-    label = "_main"
-    header = ".globl " <> label <> "\n" <>
-      label <> ":\n"
-    instructionsTxt = T.concat $ Prelude.map emitInstruction instructions
+    header = 
+      "\t.globl _main\n" <>
+      "_main:\n" <>
+      "\tpushq %rbp\n" <>
+      "\tmovq %rsp, %rbp\n"
+    instructionsTxt = T.concat $ map emitInstruction instructions
   in
     header <> instructionsTxt 
 

--- a/lib/Halcyon/Backend/ReplacePseudos.hs
+++ b/lib/Halcyon/Backend/ReplacePseudos.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE RecordWildCards #-}
+module Halcyon.Backend.ReplacePseudos where
+
+import Data.Traversable (mapAccumL)
+import qualified Data.Map.Strict as Map
+import Data.Text ( Text )
+
+import qualified Halcyon.Core.Assembly as Asm
+
+-- Structure to keep track of what stack slots we've assigned so far
+data ReplacementSt = ReplacementSt
+  { currentOffset :: Int              -- last used stack slot
+  , offsetMap     :: Map.Map Text Int -- map from pseudoregister to stack slots
+  } deriving Show
+
+replaceOperand :: ReplacementSt -> Asm.Operand -> (ReplacementSt, Asm.Operand)
+replaceOperand state (Asm.Pseudo s) = case Map.lookup s (offsetMap state) of
+  Just offset -> (state, Asm.Stack offset)
+  Nothing -> 
+    let 
+      newOffset = (currentOffset state) - 4
+      newMap = Map.insert s newOffset (offsetMap state)
+      newState = ReplacementSt {
+        currentOffset = newOffset,
+        offsetMap = newMap
+      }
+    in (newState, Asm.Stack newOffset)
+replaceOperand state other = (state, other)
+
+replacePseudoInst :: ReplacementSt -> Asm.Instruction -> (ReplacementSt, Asm.Instruction)
+replacePseudoInst state (Asm.Mov src dst) =
+  let 
+    (state1, newSrc) = replaceOperand state src
+    (state2, newDst) = replaceOperand state1 dst
+    newMov = Asm.Mov newSrc newDst
+    in (state2, newMov)
+replacePseudoInst state (Asm.Unary op dst) =
+  let
+    (state1, newDst) = replaceOperand state dst
+    newUnary = Asm.Unary op newDst
+  in (state1, newUnary)
+replacePseudoInst state Asm.Ret = (state, Asm.Ret)
+replacePseudoInst state (Asm.AllocateStack _) = (state, Asm.AllocateStack 900)
+
+replacePseudoFunc :: Asm.FunctionDef -> (ReplacementSt, Asm.FunctionDef)
+replacePseudoFunc func@Asm.Function{..} =
+  let 
+    initState = ReplacementSt { currentOffset = 0, offsetMap = Map.empty}
+    (finalState, fixedInstructions) = 
+      mapAccumL replacePseudoInst initState instructions
+
+  in (finalState, func {Asm.instructions = fixedInstructions})
+
+replacePseudos :: Asm.Program -> (Int, Asm.Program)
+replacePseudos (Asm.Program f) =
+  let (lastState, fixedF) = replacePseudoFunc f
+  in (currentOffset lastState, Asm.Program fixedF)

--- a/lib/Halcyon/Backend/ReplacePseudos.hs
+++ b/lib/Halcyon/Backend/ReplacePseudos.hs
@@ -1,7 +1,14 @@
 {-# LANGUAGE RecordWildCards #-}
-module Halcyon.Backend.ReplacePseudos where
+{-# LANGUAGE OverloadedRecordDot #-}
+module Halcyon.Backend.ReplacePseudos 
+  ( replacePseudos
+  , fixupProgram
+  , ReplacePseudosError(..)
+  , PseudoM
+  ) where
 
-import Data.Traversable (mapAccumL)
+import Control.Monad.Except
+import Control.Monad.State
 import qualified Data.Map.Strict as Map
 import Data.Text ( Text )
 
@@ -13,45 +20,79 @@ data ReplacementSt = ReplacementSt
   , offsetMap     :: Map.Map Text Int -- map from pseudoregister to stack slots
   } deriving Show
 
-replaceOperand :: ReplacementSt -> Asm.Operand -> (ReplacementSt, Asm.Operand)
-replaceOperand state (Asm.Pseudo s) = case Map.lookup s (offsetMap state) of
-  Just offset -> (state, Asm.Stack offset)
-  Nothing -> 
-    let 
-      newOffset = (currentOffset state) - 4
-      newMap = Map.insert s newOffset (offsetMap state)
-      newState = ReplacementSt {
+data ReplacePseudosError 
+  = UnexpectedAllocateStack
+  deriving (Show, Eq)
+
+type PseudoM = Either ReplacePseudosError
+
+-- | State monad transformer that can also fail with ReplacePseudosError
+type ReplaceM = StateT ReplacementSt PseudoM
+
+-- | Constraint for monads that can perform compiler operations
+type MonadReplace m = 
+  ( MonadState ReplacementSt m
+  , MonadError ReplacePseudosError m
+  )
+
+replaceOperand :: MonadReplace m => Asm.Operand -> m Asm.Operand
+replaceOperand (Asm.Pseudo s) = do
+  st <- get
+  case Map.lookup s st.offsetMap of
+    Just offset -> pure $ Asm.Stack offset
+    Nothing -> do
+      let 
+        newOffset =  st.currentOffset - 4
+        newMap = Map.insert s newOffset st.offsetMap
+      put $ ReplacementSt {
         currentOffset = newOffset,
         offsetMap = newMap
       }
-    in (newState, Asm.Stack newOffset)
-replaceOperand state other = (state, other)
+      pure $ Asm.Stack newOffset
+replaceOperand other = pure other
 
-replacePseudoInst :: ReplacementSt -> Asm.Instruction -> (ReplacementSt, Asm.Instruction)
-replacePseudoInst state (Asm.Mov src dst) =
-  let 
-    (state1, newSrc) = replaceOperand state src
-    (state2, newDst) = replaceOperand state1 dst
-    newMov = Asm.Mov newSrc newDst
-    in (state2, newMov)
-replacePseudoInst state (Asm.Unary op dst) =
-  let
-    (state1, newDst) = replaceOperand state dst
-    newUnary = Asm.Unary op newDst
-  in (state1, newUnary)
-replacePseudoInst state Asm.Ret = (state, Asm.Ret)
-replacePseudoInst state (Asm.AllocateStack _) = (state, Asm.AllocateStack 900)
+replacePseudoInst :: MonadReplace m => Asm.Instruction -> m Asm.Instruction
+replacePseudoInst = \case
+  Asm.Mov src dst -> do
+    newSrc <- replaceOperand src
+    newDst <- replaceOperand dst
+    pure $ Asm.Mov newSrc newDst
+  Asm.Unary op dst -> do
+    newDst <- replaceOperand dst
+    pure $ Asm.Unary op newDst
+  Asm.Ret -> pure Asm.Ret
+  Asm.AllocateStack _ -> throwError UnexpectedAllocateStack
 
-replacePseudoFunc :: Asm.FunctionDef -> (ReplacementSt, Asm.FunctionDef)
-replacePseudoFunc func@Asm.Function{..} =
-  let 
-    initState = ReplacementSt { currentOffset = 0, offsetMap = Map.empty}
-    (finalState, fixedInstructions) = 
-      mapAccumL replacePseudoInst initState instructions
+replacePseudoFunc :: MonadReplace m => Asm.FunctionDef -> m Asm.FunctionDef
+replacePseudoFunc func@Asm.Function{..} = do
+  fixedInstructions <- traverse replacePseudoInst instructions
+  pure $ func { Asm.instructions = fixedInstructions }
 
-  in (finalState, func {Asm.instructions = fixedInstructions})
+replacePseudos :: Asm.Program -> PseudoM (Asm.Program, Int)
+replacePseudos (Asm.Program f) = do
+  let initState = ReplacementSt 
+        { currentOffset = 0
+        , offsetMap = Map.empty
+        }
+  -- Run the stateful computation and get both result and final state
+  (fixedF, finalState) <- runStateT (replacePseudoFunc f) initState
+  -- Return the program and just the offset we need
+  pure (Asm.Program fixedF, currentOffset finalState)
 
-replacePseudos :: Asm.Program -> (Int, Asm.Program)
-replacePseudos (Asm.Program f) =
-  let (lastState, fixedF) = replacePseudoFunc f
-  in (currentOffset lastState, Asm.Program fixedF)
+fixupInstruction :: Asm.Instruction -> [Asm.Instruction]
+fixupInstruction (Asm.Mov (Asm.Stack src) (Asm.Stack dst)) = 
+  [ (Asm.Mov (Asm.Stack src) (Asm.Register Asm.R10)) 
+  , (Asm.Mov (Asm.Register Asm.R10) (Asm.Stack dst)) ]
+fixupInstruction other = [ other ]
+
+fixupFunction :: Asm.FunctionDef -> Int ->Asm.FunctionDef
+fixupFunction (Asm.Function{..}) lastStackSlot = Asm.Function 
+  { name
+  , instructions = 
+      (Asm.AllocateStack lastStackSlot) 
+        : concatMap fixupInstruction instructions
+  }
+
+fixupProgram :: Asm.Program -> Int -> Asm.Program
+fixupProgram (Asm.Program f) lastStackSlot =
+  Asm.Program (fixupFunction f lastStackSlot) 

--- a/lib/Halcyon/Core/Assembly.hs
+++ b/lib/Halcyon/Core/Assembly.hs
@@ -2,23 +2,6 @@ module Halcyon.Core.Assembly where
 
 import Data.Text ( Text )
 
-{-
-program = Program(function_definition)
-function_definition = Function(identifier name, instruction* instructions)
-instruction 
-  = Mov(operand src, operand dst)
-  | Unary(unary_operator, operand)
-  | AllocateStack(int)
-  | Ret
-unary_operator = Neg | Not
-operand 
-  = Imm(int) 
-  | Reg(reg) 
-  | Pseudo(identifier) 
-  | Stack(int)
-reg = AX | R10
--}
-
 --TODO: use record syntax to name some of the product types
 -- e.i. Mov Operand Operand -> Mov {src: Operand, dest: Operand}
 data Program = Program FunctionDef
@@ -48,3 +31,20 @@ data Operand
 
 data Reg = Ax | R10
   deriving (Eq, Show)
+
+{-
+program = Program(function_definition)
+function_definition = Function(identifier name, instruction* instructions)
+instruction 
+  = Mov(operand src, operand dst)
+  | Unary(unary_operator, operand)
+  | AllocateStack(int)
+  | Ret
+unary_operator = Neg | Not
+operand 
+  = Imm(int) 
+  | Reg(reg) 
+  | Pseudo(identifier) 
+  | Stack(int)
+reg = AX | R10
+-}

--- a/lib/Halcyon/Core/Assembly.hs
+++ b/lib/Halcyon/Core/Assembly.hs
@@ -2,12 +2,25 @@ module Halcyon.Core.Assembly where
 
 import Data.Text ( Text )
 
--- AST ASDL
--- program = Program(function_definition)
--- function_definition = Function(identifier name, instruction* instructions)
--- instruction = Mov(operand src, operand dst) | Ret
--- operand = Imm(int) | Register
+{-
+program = Program(function_definition)
+function_definition = Function(identifier name, instruction* instructions)
+instruction 
+  = Mov(operand src, operand dst)
+  | Unary(unary_operator, operand)
+  | AllocateStack(int)
+  | Ret
+unary_operator = Neg | Not
+operand 
+  = Imm(int) 
+  | Reg(reg) 
+  | Pseudo(identifier) 
+  | Stack(int)
+reg = AX | R10
+-}
 
+--TODO: use record syntax to name some of the product types
+-- e.i. Mov Operand Operand -> Mov {src: Operand, dest: Operand}
 data Program = Program FunctionDef
   deriving (Eq, Show)
 
@@ -16,8 +29,22 @@ data FunctionDef = Function
   , instructions :: [Instruction]
   } deriving (Eq, Show)
 
-data Instruction = Mov Operand Operand | Ret
+data Instruction 
+  = Mov Operand Operand
+  | Unary UnaryOp Operand
+  | AllocateStack Int
+  | Ret
   deriving (Eq, Show)
 
-data Operand = Imm Int | Register
+data UnaryOp = Neg | Not
+  deriving (Eq, Show)
+
+data Operand 
+  = Imm Int 
+  | Register Reg
+  | Pseudo Text
+  | Stack Int
+  deriving (Eq, Show)
+
+data Reg = Ax | R10
   deriving (Eq, Show)

--- a/lib/Halcyon/Core/Ast.hs
+++ b/lib/Halcyon/Core/Ast.hs
@@ -13,19 +13,24 @@ data FunctionDef = Function
 data Statement = Return Expr
   deriving Show
 
-data Expr = Constant Int
+data Expr = Constant Int | Unary UnaryOp Expr
+  deriving Show
+
+data UnaryOp = Complement | Negate
   deriving Show
 
 -- Formal Grammar in EBNF
 -- <program> ::= <function>
 -- <function> ::= "int" <identifier> "(" "void" ")" "{" <statement> "}"
 -- <statement> ::= "return" <exp> ";"
--- <exp> ::= <int>
+-- <exp> ::= <int> | <unop> <exp> | "(" <exp> ")"
+-- <unop> ::= "-" | "~"
 -- <identifier> ::= ? An identifier token ?
 -- <int> ::= ? A constant token ?
 
 -- AST in ASDL
---program = Program(function_definition)
---function_definition = Function(identifier name, statement body)
---statement = Return(exp)
---exp = Constant(int)
+-- program = Program(function_definition)
+-- function_definition = Function(identifier name, statement body)
+-- statement = Return(exp)
+-- exp = Constant(int) | Unary(unary_op, exp)
+-- unaryOp = Complement | Negate

--- a/lib/Halcyon/Core/Settings.hs
+++ b/lib/Halcyon/Core/Settings.hs
@@ -5,11 +5,13 @@ import Data.Text (Text)
 import Halcyon.Frontend.Tokens (CToken)
 import qualified Halcyon.Core.Ast as Ast
 import qualified Halcyon.Core.Assembly as Asm
+import qualified Halcyon.Core.Tacky as Tacky
 
 
-data Stage = 
-    Lex
+data Stage 
+  = Lex
   | Parse
+  | Tacky
   | Codegen
   | Assembly
   | Executable
@@ -21,6 +23,7 @@ data Target = OSX | Linux
 data StageResult
   = StageResultTokens [CToken]
   | StageResultAST Ast.Program
+  | StageResultTacky Tacky.Program
   | StageResultAsm Asm.Program
   | StageResultAssembly Text
   | StageResultExecutable Text

--- a/lib/Halcyon/Core/Tacky.hs
+++ b/lib/Halcyon/Core/Tacky.hs
@@ -1,0 +1,32 @@
+module Halcyon.Core.Tacky where
+
+import Data.Text ( Text )
+
+data Program = Program FunctionDef
+  deriving (Eq, Show)
+
+data FunctionDef = Function
+  { name :: Text
+  , body :: [Instruction]
+  } deriving (Eq, Show)
+
+data Instruction 
+  = Return TackyVal
+  | Unary UnaryOp TackyVal TackyVal
+  deriving (Eq, Show)
+
+data TackyVal
+  = Constant Int
+  | Var Text
+  deriving (Eq, Show)
+
+data UnaryOp
+  = Complement
+  | Negate
+  deriving (Eq, Show)
+
+--program = Program(function_definition)
+--function_definition = Function(identifier, instruction* body)
+--instruction = Return(val) | Unary(unary_operator, val src, val dst)
+--val = Constant(int) | Var(identifier)
+--unary_operator = Complement | Negate

--- a/lib/Halcyon/Core/TackyGen.hs
+++ b/lib/Halcyon/Core/TackyGen.hs
@@ -1,0 +1,64 @@
+{-#LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module Halcyon.Core.TackyGen where
+
+import Control.Monad.State
+import Data.Text (Text)
+import qualified Data.Text as T
+
+import Halcyon.Core.Ast qualified as Ast  
+import Halcyon.Core.Tacky qualified as Tacky
+import Halcyon.Core.Monad (Compiler)
+
+newtype TackyGenT m a = TackyGenT 
+  { runTackyGenT :: StateT Int m a }
+  deriving (Functor, Applicative, Monad, MonadState Int)
+
+data TackyGenRes = TackyGenRes
+  { instructions :: [Tacky.Instruction]
+  , resultVal :: Tacky.TackyVal 
+  } deriving (Show, Eq)
+
+-- Helper to generate unique names
+freshTemp :: Monad m => TackyGenT m Text
+freshTemp = do
+  n <- get
+  put (n + 1)
+  pure $ "tmp." <> T.pack (show n)
+
+convertOp :: Ast.UnaryOp -> Tacky.UnaryOp
+convertOp Ast.Complement = Tacky.Complement
+convertOp Ast.Negate     = Tacky.Negate
+
+emitTackyForExpr :: Monad m => Ast.Expr -> TackyGenT m TackyGenRes
+emitTackyForExpr = \case
+  Ast.Constant c -> pure $ TackyGenRes 
+    { instructions = [], resultVal = Tacky.Constant c }
+  Ast.Unary op inner -> do
+    dstName <- freshTemp
+    TackyGenRes{..} <- emitTackyForExpr inner
+    let 
+      dst = Tacky.Var dstName
+      tackyOp = convertOp op
+      newInstr = Tacky.Unary tackyOp resultVal dst
+    pure $ TackyGenRes
+      { instructions = instructions ++ [newInstr], resultVal = dst }
+        
+emitTackyForStmnt :: Monad m => Ast.Statement -> TackyGenT m TackyGenRes
+emitTackyForStmnt (Ast.Return e) = do
+  TackyGenRes{..} <- emitTackyForExpr e
+  pure $ TackyGenRes {..}
+
+emitTackyForFunc :: Monad m => Ast.FunctionDef -> TackyGenT m Tacky.FunctionDef
+emitTackyForFunc Ast.Function{..} = do
+  TackyGenRes{..} <- emitTackyForStmnt body
+  let finalInstrs = instructions ++ [Tacky.Return resultVal]
+  pure $ Tacky.Function {name, body = finalInstrs}
+
+emitTackyProgram :: Monad m => Ast.Program -> TackyGenT m Tacky.Program
+emitTackyProgram (Ast.Program fnDef) = do
+  tackyFunc <- emitTackyForFunc fnDef
+  pure $ Tacky.Program tackyFunc
+
+genTacky :: Ast.Program -> Compiler Tacky.Program 
+genTacky program = evalStateT (runTackyGenT $ emitTackyProgram program) 0

--- a/lib/Halcyon/Core/TackyGen.hs
+++ b/lib/Halcyon/Core/TackyGen.hs
@@ -1,6 +1,8 @@
 {-#LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-module Halcyon.Core.TackyGen where
+module Halcyon.Core.TackyGen 
+( genTacky
+) where
 
 import Control.Monad.State
 import Data.Text (Text)
@@ -8,7 +10,7 @@ import qualified Data.Text as T
 
 import Halcyon.Core.Ast qualified as Ast  
 import Halcyon.Core.Tacky qualified as Tacky
-import Halcyon.Core.Monad (Compiler)
+import Halcyon.Core.Monad (MonadCompiler)
 
 newtype TackyGenT m a = TackyGenT 
   { runTackyGenT :: StateT Int m a }
@@ -60,5 +62,6 @@ emitTackyProgram (Ast.Program fnDef) = do
   tackyFunc <- emitTackyForFunc fnDef
   pure $ Tacky.Program tackyFunc
 
-genTacky :: Ast.Program -> Compiler Tacky.Program 
-genTacky program = evalStateT (runTackyGenT $ emitTackyProgram program) 0
+genTacky :: MonadCompiler m => Ast.Program -> m Tacky.Program 
+genTacky program = 
+  evalStateT (runTackyGenT $ emitTackyProgram program) 0

--- a/lib/Halcyon/Driver/Cli.hs
+++ b/lib/Halcyon/Driver/Cli.hs
@@ -16,9 +16,10 @@ data AppOptions = AppOptions
 
 stageParser :: Parser Stage
 stageParser = 
-      flag' Lex     (long "lex"     <> help "Run the lexer")
-  <|> flag' Parse   (long "parse"   <> help "Run the lexer and parser")
-  <|> flag' Codegen (long "codegen" <> help "Run through code generation")
+      flag' Lex      (long "lex"     <> help "Run the lexer")
+  <|> flag' Parse    (long "parse"   <> help "Run the lexer and parser")
+  <|> flag' Tacky    (long "tacky"   <> help "Run the lexer, parser, and tacky generator")
+  <|> flag' Codegen  (long "codegen" <> help "Run through code generation")
   <|> flag' Assembly (long "S"      <> help "Stop before assembling")
   <|> pure Executable  -- Default value if no flag is provided
 

--- a/lib/Halcyon/Driver/Pipeline.hs
+++ b/lib/Halcyon/Driver/Pipeline.hs
@@ -8,6 +8,10 @@ module Halcyon.Driver.Pipeline
   , handleStageResult
   ) where
 
+
+import qualified System.IO as SIO
+
+
 import Halcyon.Core.Monad
 import qualified Halcyon.Core.Tacky as Tacky
 import Halcyon.Core.TackyGen
@@ -16,6 +20,7 @@ import qualified Halcyon.Frontend.Lexer as Lexer
 import qualified Halcyon.Frontend.Parse as Parse
 import qualified Halcyon.Backend.Codegen as Codegen
 import qualified Halcyon.Backend.Emit as Emit
+import qualified Halcyon.Backend.ReplacePseudos as Replace
 import qualified Halcyon.Core.Assembly as Asm
 import qualified Halcyon.Core.Ast as Ast
 import Halcyon.Core.Settings (StageResult(..))
@@ -55,13 +60,13 @@ runCompilerStages AppOptions{..} src = case stage of
   Parse -> StageResultAST <$> 
     (runLexStage src >>= runParseStage)
   Tacky -> StageResultTacky <$>
-    (runLexStage src >>= runParseStage >>= runTackyStage)
+    (runLexStage src >>= runParseStage >>= debugStage "AST" >>= runTackyStage)
   Codegen -> StageResultAsm <$> 
-    (runLexStage src >>= runParseStage >>= runCodegenStage)
+    (runLexStage src >>= runParseStage >>= runTackyStage >>= debugStage "TACKY" >>= runCodegenStage)
   Assembly -> StageResultAssembly <$>
-    (runLexStage src >>= runParseStage >>= runCodegenStage >>= runEmitStage)
+    (runLexStage src >>= runParseStage >>= runTackyStage >>= runCodegenStage >>= runFixupStage >>= debugStage "ASM" >>= runEmitStage)
   Executable -> StageResultExecutable <$>
-    (runLexStage src >>= runParseStage >>= runCodegenStage >>= runEmitStage)
+    (runLexStage src >>= runParseStage >>= runTackyStage >>= runCodegenStage >>= runFixupStage >>= runEmitStage)
   where
     runLexStage :: MonadCompiler m => T.Text -> m [Tokens.CToken]
     runLexStage input = liftLexResult $ runParser Lexer.lexer "" input
@@ -69,10 +74,21 @@ runCompilerStages AppOptions{..} src = case stage of
     runParseStage = liftParseResult . Parse.parseTokens
     runTackyStage :: MonadCompiler m => Ast.Program -> m Tacky.Program
     runTackyStage = genTacky
-    runCodegenStage :: MonadCompiler m => Ast.Program -> m Asm.Program
-    runCodegenStage = liftCompilerEither . Codegen.gen
+    runCodegenStage :: MonadCompiler m => Tacky.Program -> m Asm.Program
+    runCodegenStage = return . Codegen.gen
+    runFixupStage :: MonadCompiler m => Asm.Program -> m Asm.Program
+    runFixupStage program = do
+      case Replace.replacePseudos program of
+        Left err -> throwError $ CodegenError $ "Pseudo replacement failed: " <> T.pack (show err)
+        Right (programWithStacks, lastOffset) -> 
+          return $ Replace.fixupProgram programWithStacks lastOffset
     runEmitStage :: MonadCompiler m => Asm.Program -> m T.Text
     runEmitStage = return . Emit.emitProgram
+    debugStage :: (Show a, MonadCompiler m) => String -> a -> m a 
+    debugStage label x = do
+      liftIO $ SIO.hPutStrLn SIO.stderr $ "\n=== " ++ label ++ " ===\n" ++ show x
+      liftIO $ SIO.hFlush SIO.stderr
+      return x
 
 -- | Handle the result of compilation
 handleStageResult :: MonadCompiler m => AppOptions -> StageResult -> m ()

--- a/lib/Halcyon/Frontend/Lexer.hs
+++ b/lib/Halcyon/Frontend/Lexer.hs
@@ -74,11 +74,14 @@ pToken = choice
   [ pKeyword "int"
   , pKeyword "void"
   , pKeyword "return"
-  , pSymbol "(" TokLParen
-  , pSymbol ")" TokRParen
-  , pSymbol "{" TokLBrace
-  , pSymbol "}" TokRBrace
-  , pSymbol ";" TokSemicolon
+  , pSymbol "("  TokLParen
+  , pSymbol ")"  TokRParen
+  , pSymbol "{"  TokLBrace
+  , pSymbol "}"  TokRBrace
+  , pSymbol ";"  TokSemicolon
+  , pSymbol "-"  TokHyphen
+  , pSymbol "--" TokDoubleHyphen
+  , pSymbol "~"  TokTilde
   , pIdentifier
   , pNumber
   ] <?> "token"

--- a/lib/Halcyon/Frontend/Parse.hs
+++ b/lib/Halcyon/Frontend/Parse.hs
@@ -6,14 +6,16 @@ module Halcyon.Frontend.Parse
   ) where
 
 import Control.Monad (void)
+import Control.Monad.Combinators.Expr
 import Data.Text (Text)
 import qualified Data.Set as Set
 import Data.List.NonEmpty (NonEmpty(..))
 import Text.Megaparsec
+import Text.Megaparsec.Debug (dbg)
 
 import Halcyon.Frontend.Tokens
 import Halcyon.Core.Ast
-    ( Program(..), Expr(..), FunctionDef(Function), Statement(..) )
+    ( Program(..), Expr(..), FunctionDef(Function), Statement(..), UnaryOp(..) )
 
 -- Type aliases to make signatures cleaner
 type Parser = Parsec CParseError [CToken]
@@ -69,12 +71,40 @@ parseReturn = do
 
 -- Expression parsers
 parseExpr :: Parser Expr
-parseExpr = parseTerm <?> "expression"
+parseExpr = dbg "expr" (choice
+  [ dbg "unary" parseUnary <?> "unary operator"
+  , dbg "term" parseTerm <?> "term"
+  ] <?> "expression")
 
 parseTerm :: Parser Expr
-parseTerm = choice
-  [ Constant <$> number
-  ] <?> "term"
+parseTerm = dbg "term" (choice
+  [ dbg "constant" (Constant <$> number)
+  , dbg "paren expr" (parens parseExpr)
+  ] <?> "term")
+
+parens :: Parser a -> Parser a
+parens = between
+  (matchToken TokLParen)
+  (matchToken TokRParen)
+
+parseUnary :: Parser Expr
+parseUnary = dbg "unary" $ do
+  op <- dbg "unaryOp" pUnaryOp
+  expr <- dbg "unaryExp" parseExpr
+  case op of
+    TokTilde -> 
+      pure $ Unary Complement expr
+    TokHyphen -> 
+      pure $ Unary Negate expr
+    TokDoubleHyphen -> 
+      customFailure $ UnexpectedToken TokDoubleHyphen "Not yet implemented"
+    badTok -> 
+      customFailure $ UnexpectedToken badTok "No."
+
+pUnaryOp :: Parser CToken
+pUnaryOp = (matchToken TokTilde <?> "bitwise complement operator")
+  <|> (matchToken TokHyphen <?> "negation operator")
+  <|> (matchToken TokDoubleHyphen <?> "decrement operator")
 
 -- Token level parsers
 matchToken :: CToken -> Parser CToken

--- a/lib/Halcyon/Frontend/Parse.hs
+++ b/lib/Halcyon/Frontend/Parse.hs
@@ -71,16 +71,14 @@ parseReturn = do
 
 -- Expression parsers
 parseExpr :: Parser Expr
-parseExpr = dbg "expr" (choice
-  [ dbg "unary" parseUnary <?> "unary operator"
-  , dbg "term" parseTerm <?> "term"
-  ] <?> "expression")
+parseExpr = dbg "expr" $ parseTerm
 
 parseTerm :: Parser Expr
-parseTerm = dbg "term" (choice
-  [ dbg "constant" (Constant <$> number)
-  , dbg "paren expr" (parens parseExpr)
-  ] <?> "term")
+parseTerm = dbg "term" $ choice
+  [ parens parseExpr
+  , parseUnary
+  , Constant <$> number
+  ]
 
 parens :: Parser a -> Parser a
 parens = between
@@ -89,8 +87,8 @@ parens = between
 
 parseUnary :: Parser Expr
 parseUnary = dbg "unary" $ do
-  op <- dbg "unaryOp" pUnaryOp
-  expr <- dbg "unaryExp" parseExpr
+  op <- pUnaryOp
+  expr <- parseTerm
   case op of
     TokTilde -> 
       pure $ Unary Complement expr

--- a/lib/Halcyon/Frontend/Tokens.hs
+++ b/lib/Halcyon/Frontend/Tokens.hs
@@ -110,6 +110,9 @@ instance ShowErrorComponent CToken where
     TokLBrace -> "left brace '{'"
     TokRBrace -> "right brace '}'"
     TokSemicolon -> "semicolon ';'"
+    TokTilde -> "tilde '~'"
+    TokHyphen -> "hyphen '-'"
+    TokDoubleHyphen -> "double hyphen '--'"
 
 -- For better error messages - shows a preview of tokens
 instance VisualStream [CToken] where

--- a/lib/Halcyon/Frontend/Tokens.hs
+++ b/lib/Halcyon/Frontend/Tokens.hs
@@ -20,16 +20,19 @@ import qualified Data.List.NonEmpty as NE
 
 -- | Tokens produced by lexical analysis
 data CToken
-  = TokInt        
-  | TokVoid      
-  | TokReturn    
+  = TokInt       
+  | TokVoid    
+  | TokReturn 
   | TokIdent Text
   | TokNumber Int
   | TokLParen    
   | TokRParen    
   | TokLBrace    
   | TokRBrace    
-  | TokSemicolon 
+  | TokSemicolon
+  | TokHyphen
+  | TokDoubleHyphen  
+  | TokTilde
   deriving (Eq, Show, Ord)
 
 -- | Common syntax errors that can occur in both lexing and parsing


### PR DESCRIPTION
This PR implements Chapter 2 of the compiler book, adding support for unary operators.

Key changes:
- Added support for negation (-) and bitwise complement (~) operators
- Implemented TACKY intermediate representation
- Added stack frame management and register allocation
- Created new compiler passes for TACKY transformation and assembly optimization
- Updated parser to handle nested expressions
- Extended compiler pipeline with new stages

All tests are passing.

Version bump: 0.1.0.0 -> 0.2.0.0