### PR TITLE
Refactor core types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,12 @@
   - Assembly generation tests
   - Full pipeline integration tests
 - Test utilities and helper functions in Test.Common
+
+## 0.2.2.0 -- 2024-11-25
+
+### Changed
+- Improved type definitions across compiler stages
+- Added record syntax for multi-field data constructors
+- Standardized naming conventions in core types
+- Simplified token type names
+- Made qualified imports consistent across modules

--- a/README.md
+++ b/README.md
@@ -27,40 +27,53 @@ The compiler processes source code through the following stages:
 Programs are represented internally using a series of increasingly lower-level data structures:
 
 1. **Abstract Syntax Tree (AST)**:
-   ```haskell
-   data Program = Program FunctionDef
-   data FunctionDef = Function 
-     { name :: Text
-     , body :: Statement 
-     }
-   data Statement = Return Expr
-   data Expr = Constant Int | Unary UnaryOp Expr
-   data UnaryOp = Complement | Negate
-   ```
+  ```haskell
+  data Program = Program Function
+  data Function = Function 
+    { name :: Text
+    , body :: Statement 
+    }
+  data Statement = Return Expr
+  data Expr
+    = Constant { value :: Int }
+    | Unary { operator :: UnaryOp, operand :: Expr }
+  data UnaryOp = Complement | Negate
+  ```
 
 2. **TACKY IR**:
   ```haskell
-  data Program = Program FunctionDef
-  data FunctionDef = Function 
+  data Program = Program Function
+  data Function = Function 
     { name :: Text
     , body :: [Instruction]
     }
-  data Instruction 
-    = Return TackyVal
-    | Unary UnaryOp TackyVal TackyVal
-  data TackyVal = Constant Int | Var Text
+  data Instruction
+    = Return { value :: Val }
+    | Unary { operator :: UnaryOp, src :: Val, dst :: Val }
+  data Val = Constant Int | Var Text
+  data UnaryOp = Complement | Negate
   ```
 
 3. **Assembly AST**:
-   ```haskell
-   data Program = Program FunctionDef
-   data FunctionDef = Function 
-     { name :: Text
-     , instructions :: [Instruction]
-     }
-   data Instruction = Mov Operand Operand | Ret
-   data Operand = Imm Int | Register
-   ```
+  ```haskell
+  data Program = Program Function
+  data Function = Function 
+    { name :: Text
+    , instructions :: [Instruction]
+    }
+  data Instruction
+    = Mov { src :: Operand, dst :: Operand }
+    | Unary { operator :: UnaryOp, operand :: Operand }
+    | AllocateStack { bytes :: Int }
+    | Ret
+  data Operand 
+    = Imm Int 
+    | Register Reg
+    | Pseudo Text
+    | Stack Int
+  data UnaryOp = Neg | Not
+  data Reg = Ax | R10
+  ```
 
 
 ## Project Structure

--- a/halcyon.cabal
+++ b/halcyon.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               halcyon
-version:            0.2.1.0
+version:            0.2.2.0
 -- synopsis:
 -- description:
 license:            BSD-3-Clause

--- a/lib/Halcyon/Backend/Codegen.hs
+++ b/lib/Halcyon/Backend/Codegen.hs
@@ -4,7 +4,7 @@ module Halcyon.Backend.Codegen where
 import qualified Halcyon.Core.Assembly as Asm
 import qualified Halcyon.Core.Tacky as Tacky
 
-convertVal :: Tacky.TackyVal -> Asm.Operand
+convertVal :: Tacky.Val -> Asm.Operand
 convertVal (Tacky.Constant int)   = Asm.Imm int
 convertVal (Tacky.Var identifier) = Asm.Pseudo identifier
 
@@ -25,7 +25,7 @@ convertInstruction (Tacky.Unary op src dest) =
     asmOp   = convertOp op
   in [Asm.Mov asmSrc asmDest, Asm.Unary asmOp asmDest]
 
-convertFunction :: Tacky.FunctionDef -> Asm.FunctionDef
+convertFunction :: Tacky.Function -> Asm.Function
 convertFunction Tacky.Function{..} =
   let instructions = concatMap convertInstruction body
   in Asm.Function {name, instructions}

--- a/lib/Halcyon/Backend/Emit.hs
+++ b/lib/Halcyon/Backend/Emit.hs
@@ -31,7 +31,7 @@ emitInstruction (Asm.Unary op operand) =
 emitInstruction Asm.Ret = 
   "\tmovq %rbp, %rsp\n\tpopq %rbp\n\tret\n"
 
-emitFunction :: Asm.FunctionDef -> Text
+emitFunction :: Asm.Function -> Text
 emitFunction Asm.Function{..} =
   let
     header = 

--- a/lib/Halcyon/Backend/ReplacePseudos.hs
+++ b/lib/Halcyon/Backend/ReplacePseudos.hs
@@ -63,7 +63,7 @@ replacePseudoInst = \case
   Asm.Ret -> pure Asm.Ret
   Asm.AllocateStack _ -> throwError UnexpectedAllocateStack
 
-replacePseudoFunc :: MonadReplace m => Asm.FunctionDef -> m Asm.FunctionDef
+replacePseudoFunc :: MonadReplace m => Asm.Function -> m Asm.Function
 replacePseudoFunc func@Asm.Function{..} = do
   fixedInstructions <- traverse replacePseudoInst instructions
   pure $ func { Asm.instructions = fixedInstructions }
@@ -85,7 +85,7 @@ fixupInstruction (Asm.Mov (Asm.Stack src) (Asm.Stack dst)) =
   , (Asm.Mov (Asm.Register Asm.R10) (Asm.Stack dst)) ]
 fixupInstruction other = [ other ]
 
-fixupFunction :: Asm.FunctionDef -> Int ->Asm.FunctionDef
+fixupFunction :: Asm.Function -> Int -> Asm.Function
 fixupFunction (Asm.Function{..}) lastStackSlot = Asm.Function 
   { name
   , instructions = 

--- a/lib/Halcyon/Core/Assembly.hs
+++ b/lib/Halcyon/Core/Assembly.hs
@@ -2,20 +2,19 @@ module Halcyon.Core.Assembly where
 
 import Data.Text ( Text )
 
---TODO: use record syntax to name some of the product types
--- e.i. Mov Operand Operand -> Mov {src: Operand, dest: Operand}
-data Program = Program FunctionDef
+
+data Program = Program Function
   deriving (Eq, Show)
 
-data FunctionDef = Function 
+data Function = Function 
   { name         :: Text
   , instructions :: [Instruction]
   } deriving (Eq, Show)
 
-data Instruction 
-  = Mov Operand Operand
-  | Unary UnaryOp Operand
-  | AllocateStack Int
+data Instruction
+  = Mov { src :: Operand, dst :: Operand }
+  | Unary { operator :: UnaryOp, operand :: Operand }
+  | AllocateStack { bytes :: Int }
   | Ret
   deriving (Eq, Show)
 

--- a/lib/Halcyon/Core/Ast.hs
+++ b/lib/Halcyon/Core/Ast.hs
@@ -2,10 +2,10 @@ module Halcyon.Core.Ast where
 
 import Data.Text ( Text )
 
-data Program = Program FunctionDef
+data Program = Program Function
   deriving (Eq, Show)
 
-data FunctionDef = Function 
+data Function = Function 
   { name :: Text
   , body :: Statement
   } deriving (Eq, Show)
@@ -13,7 +13,9 @@ data FunctionDef = Function
 data Statement = Return Expr
   deriving (Eq, Show)
 
-data Expr = Constant Int | Unary UnaryOp Expr
+data Expr
+  = Constant { value :: Int }
+  | Unary { operator :: UnaryOp, operand :: Expr }
   deriving (Eq, Show)
 
 data UnaryOp = Complement | Negate

--- a/lib/Halcyon/Core/Tacky.hs
+++ b/lib/Halcyon/Core/Tacky.hs
@@ -2,20 +2,24 @@ module Halcyon.Core.Tacky where
 
 import Data.Text ( Text )
 
-data Program = Program FunctionDef
+data Program = Program Function
   deriving (Eq, Show)
 
-data FunctionDef = Function
+data Function = Function
   { name :: Text
   , body :: [Instruction]
   } deriving (Eq, Show)
 
-data Instruction 
-  = Return TackyVal
-  | Unary UnaryOp TackyVal TackyVal
+data Instruction
+  = Return { value :: Val }
+  | Unary 
+    { operator :: UnaryOp
+    , src :: Val
+    , dst :: Val 
+    }
   deriving (Eq, Show)
 
-data TackyVal
+data Val
   = Constant Int
   | Var Text
   deriving (Eq, Show)

--- a/lib/Halcyon/Core/TackyGen.hs
+++ b/lib/Halcyon/Core/TackyGen.hs
@@ -18,7 +18,7 @@ newtype TackyGenT m a = TackyGenT
 
 data TackyGenRes = TackyGenRes
   { instructions :: [Tacky.Instruction]
-  , resultVal :: Tacky.TackyVal 
+  , resultVal :: Tacky.Val 
   } deriving (Show, Eq)
 
 -- Helper to generate unique names
@@ -51,7 +51,7 @@ emitTackyForStmnt (Ast.Return e) = do
   TackyGenRes{..} <- emitTackyForExpr e
   pure $ TackyGenRes {..}
 
-emitTackyForFunc :: Monad m => Ast.FunctionDef -> TackyGenT m Tacky.FunctionDef
+emitTackyForFunc :: Monad m => Ast.Function -> TackyGenT m Tacky.Function
 emitTackyForFunc Ast.Function{..} = do
   TackyGenRes{..} <- emitTackyForStmnt body
   let finalInstrs = instructions ++ [Tacky.Return resultVal]

--- a/lib/Halcyon/Frontend/Lexer.hs
+++ b/lib/Halcyon/Frontend/Lexer.hs
@@ -3,8 +3,6 @@ module Halcyon.Frontend.Lexer where
 
 import Data.Functor (($>))
 import Data.Text (Text)
-import Data.Set (Set)
-import qualified Data.Set as Set
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
@@ -35,9 +33,9 @@ pKeyword kw = lexeme $ try $ do
   notFollowedBy alphaNumChar <?> 
     "end of keyword '" <> T.unpack kw <> "'"
   return $ case kw of
-    "int"    -> TokInt
-    "void"   -> TokVoid
-    "return" -> TokReturn
+    "int"    -> KwInt
+    "void"   -> KwVoid
+    "return" -> KwReturn
     _        -> error "Invalid keyword"
 
 pIdentifier :: Lexer CToken
@@ -49,7 +47,7 @@ pIdentifier = lexeme $ try $ do
   if T.length ident > 31
     then customFailure $ LexicalError $ InvalidSequence ident 
       "identifier must be 31 characters or less"
-    else return $ TokIdent ident
+    else return $ Identifier ident
 
 pNumber :: Lexer CToken
 pNumber = lexeme $ try $ do
@@ -62,7 +60,7 @@ pNumber = lexeme $ try $ do
       let n = read digits
       in if n > (2^31 - 1) 
          then customFailure $ MalformedNumber "Integer too large"
-         else return $ TokNumber n
+         else return $ Number n
 
 pSymbol :: Text -> CToken -> Lexer CToken
 pSymbol sym tok = lexeme $ try $ 
@@ -74,14 +72,14 @@ pToken = choice
   [ pKeyword "int"
   , pKeyword "void"
   , pKeyword "return"
-  , pSymbol "("  TokLParen
-  , pSymbol ")"  TokRParen
-  , pSymbol "{"  TokLBrace
-  , pSymbol "}"  TokRBrace
-  , pSymbol ";"  TokSemicolon
-  , pSymbol "-"  TokHyphen
-  , pSymbol "--" TokDoubleHyphen
-  , pSymbol "~"  TokTilde
+  , pSymbol "("  LParen
+  , pSymbol ")"  RParen
+  , pSymbol "{"  LBrace
+  , pSymbol "}"  RBrace
+  , pSymbol ";"  Semicolon
+  , pSymbol "-"  Hyphen
+  , pSymbol "--" DoubleHyphen
+  , pSymbol "~"  Tilde
   , pIdentifier
   , pNumber
   ] <?> "token"

--- a/lib/Halcyon/Frontend/Parse.hs
+++ b/lib/Halcyon/Frontend/Parse.hs
@@ -15,7 +15,7 @@ import Text.Megaparsec.Debug (dbg)
 
 import Halcyon.Frontend.Tokens
 import Halcyon.Core.Ast
-    ( Program(..), Expr(..), FunctionDef(Function), Statement(..), UnaryOp(..) )
+    ( Program(..), Expr(..), Function(Function), Statement(..), UnaryOp(..) )
 
 -- Type aliases to make signatures cleaner
 type Parser = Parsec CParseError [CToken]
@@ -31,7 +31,7 @@ parseProgram :: Parser Program
 parseProgram = Program <$> parseFunctionDef <?> "program"
 
 -- Function definition parsers
-parseFunctionDef :: Parser FunctionDef
+parseFunctionDef :: Parser Function
 parseFunctionDef = do
   name <- parseFunctionHeader
   body <- parseFunctionBody

--- a/lib/Halcyon/Frontend/Parse.hs
+++ b/lib/Halcyon/Frontend/Parse.hs
@@ -39,21 +39,21 @@ parseFunctionDef = do
 
 parseFunctionHeader :: Parser Text
 parseFunctionHeader = do
-  void $ matchToken TokInt
+  void $ matchToken KwInt
   name <- identifier
   void $ parseParams
   return name <?> "function header"
 
 parseParams :: Parser ()
 parseParams = between 
-  (matchToken TokLParen) 
-  (matchToken TokRParen)
-  (void (matchToken TokVoid <?> "void")) <?> "function parameters"
+  (matchToken LParen) 
+  (matchToken RParen)
+  (void (matchToken KwVoid <?> "void")) <?> "function parameters"
 
 parseFunctionBody :: Parser Statement
 parseFunctionBody = between 
-  (matchToken TokLBrace)
-  (matchToken TokRBrace)
+  (matchToken LBrace)
+  (matchToken RBrace)
   parseStatement <?> "function body"
 
 -- Statement parsers
@@ -64,9 +64,9 @@ parseStatement = choice
 
 parseReturn :: Parser Statement
 parseReturn = do
-  void (matchToken TokReturn <?> "return keyword")
+  void (matchToken KwReturn <?> "return keyword")
   expr <- parseExpr
-  void (matchToken TokSemicolon <?> "semicolon")
+  void (matchToken Semicolon <?> "semicolon")
   return $ Return expr
 
 -- Expression parsers
@@ -82,27 +82,27 @@ parseTerm = dbg "term" $ choice
 
 parens :: Parser a -> Parser a
 parens = between
-  (matchToken TokLParen)
-  (matchToken TokRParen)
+  (matchToken LParen)
+  (matchToken RParen)
 
 parseUnary :: Parser Expr
 parseUnary = dbg "unary" $ do
   op <- pUnaryOp
   expr <- parseTerm
   case op of
-    TokTilde -> 
+    Tilde -> 
       pure $ Unary Complement expr
-    TokHyphen -> 
+    Hyphen -> 
       pure $ Unary Negate expr
-    TokDoubleHyphen -> 
-      customFailure $ UnexpectedToken TokDoubleHyphen "Not yet implemented"
+    DoubleHyphen -> 
+      customFailure $ UnexpectedToken DoubleHyphen "Not yet implemented"
     badTok -> 
       customFailure $ UnexpectedToken badTok "No."
 
 pUnaryOp :: Parser CToken
-pUnaryOp = (matchToken TokTilde <?> "bitwise complement operator")
-  <|> (matchToken TokHyphen <?> "negation operator")
-  <|> (matchToken TokDoubleHyphen <?> "decrement operator")
+pUnaryOp = (matchToken Tilde <?> "bitwise complement operator")
+  <|> (matchToken Hyphen <?> "negation operator")
+  <|> (matchToken DoubleHyphen <?> "decrement operator")
 
 -- Token level parsers
 matchToken :: CToken -> Parser CToken
@@ -116,13 +116,13 @@ matchToken expected = token test expectedSet <?> show expected
 identifier :: Parser Text
 identifier = token test expectedSet <?> "identifier"
   where
-    test (TokIdent t) = Just t
+    test (Identifier t) = Just t
     test _ = Nothing
     expectedSet = Set.singleton $ Label ('i' :| "dentifier")
 
 number :: Parser Int
 number = token test expectedSet <?> "number"
   where
-    test (TokNumber n) = Just n
+    test (Number n) = Just n
     test _ = Nothing
     expectedSet = Set.singleton $ Label ('n' :| "umber")

--- a/lib/Halcyon/Frontend/Tokens.hs
+++ b/lib/Halcyon/Frontend/Tokens.hs
@@ -20,19 +20,22 @@ import qualified Data.List.NonEmpty as NE
 
 -- | Tokens produced by lexical analysis
 data CToken
-  = TokInt       
-  | TokVoid    
-  | TokReturn 
-  | TokIdent Text
-  | TokNumber Int
-  | TokLParen    
-  | TokRParen    
-  | TokLBrace    
-  | TokRBrace    
-  | TokSemicolon
-  | TokHyphen
-  | TokDoubleHyphen  
-  | TokTilde
+  -- Values
+  = Identifier Text -- TokIdent Text
+  | Number Int      -- TokNumber Int
+  -- Keywords  
+  | KwInt      -- TokInt
+  | KwVoid     -- TokVoid
+  | KwReturn   -- TokReturn
+  -- Punctuation
+  | LParen       -- TokLParen
+  | RParen      -- TokRParen
+  | LBrace       -- TokLBrace
+  | RBrace      -- TokRBrace
+  | Semicolon       -- TokSemicolon
+  | Hyphen          -- TokHyphen
+  | DoubleHyphen    -- TokDoubleHyphen
+  | Tilde           -- TokTilde
   deriving (Eq, Show, Ord)
 
 -- | Common syntax errors that can occur in both lexing and parsing
@@ -100,19 +103,19 @@ formatSyntaxError = \case
 instance ShowErrorComponent CToken where
   showErrorComponent :: CToken -> String
   showErrorComponent = \case
-    TokInt -> "keyword 'int'"
-    TokVoid -> "keyword 'void'"
-    TokReturn -> "keyword 'return'"
-    TokIdent t -> "identifier '" <> T.unpack t <> "'"
-    TokNumber n -> "number " <> show n
-    TokLParen -> "left parenthesis '('"
-    TokRParen -> "right parenthesis ')'"
-    TokLBrace -> "left brace '{'"
-    TokRBrace -> "right brace '}'"
-    TokSemicolon -> "semicolon ';'"
-    TokTilde -> "tilde '~'"
-    TokHyphen -> "hyphen '-'"
-    TokDoubleHyphen -> "double hyphen '--'"
+    KwInt -> "keyword 'int'"
+    KwVoid -> "keyword 'void'"
+    KwReturn -> "keyword 'return'"
+    Identifier t -> "identifier '" <> T.unpack t <> "'"
+    Number n -> "number " <> show n
+    LParen -> "left parenthesis '('"
+    RParen -> "right parenthesis ')'"
+    LBrace -> "left brace '{'"
+    RBrace -> "right brace '}'"
+    Semicolon -> "semicolon ';'"
+    Tilde -> "tilde '~'"
+    Hyphen -> "hyphen '-'"
+    DoubleHyphen -> "double hyphen '--'"
 
 -- For better error messages - shows a preview of tokens
 instance VisualStream [CToken] where


### PR DESCRIPTION
- Use consistent naming across AST/TACKY/Assembly
- Add record syntax for multi-field constructors 
- Remove redundant type prefixes
- Improve token naming conventions